### PR TITLE
Limitado el registro de actores a 10 por película

### DIFF
--- a/src/main/java/com/cine/movie/controller/MovieController.java
+++ b/src/main/java/com/cine/movie/controller/MovieController.java
@@ -3,6 +3,7 @@ package com.cine.movie.controller;
 import com.cine.movie.DTO.DetailsMovie;
 import com.cine.movie.DTO.SearchMovie;
 import com.cine.movie.domain.service.API.ApiDetailsMovieService;
+import com.cine.movie.domain.service.API.IApiDetailsMovie;
 import com.cine.movie.domain.service.API.IApiSearchMovie;
 import com.cine.movie.domain.service.IMovie;
 import com.cine.movie.persistence.Movie;
@@ -21,7 +22,7 @@ import java.util.Map;
 @RequestMapping("/movies")
 public class MovieController {
   @Autowired private IApiSearchMovie apiSearchMovie;
-  @Autowired private ApiDetailsMovieService apiDetailsMovieService;
+  @Autowired private IApiDetailsMovie apiDetailsMovieService;
   @Autowired private IMovie movieService;
 
   @GetMapping("/tmdb/search/{name}")

--- a/src/main/java/com/cine/movie/domain/service/MovieService.java
+++ b/src/main/java/com/cine/movie/domain/service/MovieService.java
@@ -124,6 +124,8 @@ public class MovieService implements IMovie {
     return castingDTOS.stream()
         .map(cast -> actorRepository.findById(cast.id()).orElseGet(() -> createNewActor(cast.id())))
         .filter(Objects::nonNull)
+        // Registrar solo los 10 primeros actores de la película
+        .limit(10)
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
Este Pull Request introduce una restricción en el registro de actores para cada película. Ahora, el sistema limita el número de actores vinculados a un máximo de 10 por película, lo que ayuda a evitar guardar actores que no sean relevantes.

- Se implementó un limit(10) en el stream que procesa la búsqueda y el almacenamiento de actores en la base de datos local.

- Los actores se vinculan correctamente a la película solo hasta el máximo permitido de 10.

Issue resuelta:
Closes #7